### PR TITLE
Ensure latest inline-source is pulled-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "inline-source": "1.0.0",
+    "inline-source": "~1.0.0",
     "gulp-util": "~2.2.14",
     "through2": "~0.4.1"
   },


### PR DESCRIPTION
Current inline-source is pinned to 1.0.0, which contains a bug regarding inlining of JavaScript like "$&&(doSomething)". This was fixed in 1.0.1. I suggest allowing latest dot versions like it is done for the other dependencies.
