### PR TITLE
Fixed issue with options object creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,18 @@ function gulpInlineSource (options) {
             return cb();
         }
 
-        options = options || {};
-        options.rootpath = options.rootpath || file.base;
-        options.htmlpath = options.htmlpath || file.path;
+        var fileOptions = {
+          rootpath: file.base,
+          htmlpath: file.path
+        };
 
-        inlineSource(file.contents.toString(), options, function (err, html) {
+        if (options) {
+          for (var i in options) {
+            fileOptions[i] = options[i];
+          }
+        }
+
+        inlineSource(file.contents.toString(), fileOptions, function (err, html) {
             if (err) {
                 self.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
             } else {


### PR DESCRIPTION
This fixes a situation when we don't give any options for the plugin and we are processing more than one file:

First file: 
file.path is "X/Y/A.html"
[OK] options.rootpath is "X"
[OK] options.htmlpath is "Y/X/A.html"

Second file:
file.path is "X/Y/B.html"
[NOT] options.rootpath is "X"
[NOT] options.htmlpath is "Y/X/A.html"

So it no options was specified, it was creating options object with properties that had values of the first file, which of course was causing a n Error because it could not load a inlined stylsheet from the right location (in the second processed file).