### PR TITLE
Work better with inline-source 5.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var inlineSource = require('inline-source'),
     gutil = require('gulp-util'),
+    path = require('path'),
     through = require('through2');
 
 const PLUGIN_NAME = 'gulp-inline-source';
@@ -21,7 +22,7 @@ function gulpInlineSource (options) {
         }
 
         var fileOptions = {
-          rootpath: file.base,
+          rootpath: path.dirname(file.path),
           htmlpath: file.path
         };
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "gulp-util": "~3.0.6",
-    "inline-source": "~5.0.0",
+    "inline-source": "^5.0.0",
     "through2": "~2.0.0"
   },
   "main": "index.js",


### PR DESCRIPTION
Changed inline source dependency to `^5.0.0`... This way we get all 5.x.x

`inline-source` just released 5.2.0 where we can inline every tag (not only pre-selected ones with `inline` attribute)