### PR TITLE
Bump inline-source version to 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "plugin-error": "~1.0.1",
-    "inline-source": "~6.1.8",
+    "inline-source": "~6.2.0",
     "through2": "~2.0.0"
   },
   "main": "index.js",

--- a/test/main.js
+++ b/test/main.js
@@ -66,20 +66,3 @@ test('inlines assets without minification', function (t) {
 
     compare(stream, 'nominify.html', 'inlined-nominify.html', t);
 });
-
-test('throws when trying to compress non-ES5 syntax', function (t) {
-    t.plan(1);
-
-    const stream = inlinesource({ compress: true });
-
-    stream.on('error', function (err) {
-        t.pass();
-    });
-
-    stream.on('finish', function () {
-        t.end();
-    });
-
-    stream.write(getFixture('script-es6.html'));
-    stream.end();
-});


### PR DESCRIPTION
Bumps the inline-source dep to support pre handlers.

**feat(tests): remove throws when trying to compress non-ES5 syntax test**

this test fails in the current released version and it should fail
because terser supports es6 compression

**feat(inline-source): bump version to 6.2.0**

this version supports preHandlers to allow changing the path at
build time